### PR TITLE
fix(#5): auto-detect java_version for curated repos during discovery …

### DIFF
--- a/src/main/java/com/swebench/pipeline/RepositoryDiscovery.java
+++ b/src/main/java/com/swebench/pipeline/RepositoryDiscovery.java
@@ -98,6 +98,21 @@ public class RepositoryDiscovery {
             }
             logger.info("Loaded {} curated repositories", repositories.size());
 
+            // Auto-detect java_version for any repo that doesn't have it yet.
+            // Result is written back to curated_repos.json so subsequent runs use the cached value.
+            boolean anyEnriched = false;
+            for (Repository repo : repositories) {
+                if (repo.getJavaVersion() == null || repo.getJavaVersion().isEmpty()) {
+                    logger.info("java_version missing for {}, detecting via GitHub API...", repo.getFullName());
+                    gitHubService.enrichJavaVersion(repo);
+                    anyEnriched = true;
+                }
+            }
+            if (anyEnriched) {
+                objectMapper.writeValue(curatedFile, repositories);
+                logger.info("Saved enriched java_version values back to {}", CURATED_REPOS_FILE);
+            }
+
         } catch (IOException e) {
             logger.error("Failed to load curated repos: {}", e.getMessage());
             return searchGitHubRepositories();

--- a/src/main/java/com/swebench/service/GitHubService.java
+++ b/src/main/java/com/swebench/service/GitHubService.java
@@ -1161,6 +1161,28 @@ public class GitHubService {
     }
 
     /**
+     * Detects and sets the Java version for a curated Repository by reading its build config
+     * files from GitHub. Only makes an API call if java_version is not already set.
+     *
+     * This is the public entry point used by RepositoryDiscovery when loading curated repos.
+     */
+    public void enrichJavaVersion(Repository repo) {
+        if (repo.getJavaVersion() != null && !repo.getJavaVersion().isEmpty()) {
+            return; // already set — respect the cached / manually curated value
+        }
+        try {
+            GHRepository ghRepo = github.getRepository(repo.getFullName());
+            String version = detectJavaVersion(ghRepo);
+            repo.setJavaVersion(version);
+            logger.info("Detected java_version={} for {}", version, repo.getFullName());
+        } catch (IOException e) {
+            logger.warn("Could not fetch repo {} for java_version detection: {}, defaulting to 17",
+                    repo.getFullName(), e.getMessage());
+            repo.setJavaVersion("17");
+        }
+    }
+
+    /**
      * Generate appropriate test command based on build tool
      */
     private void generateTestCommand(TaskInstance task) {


### PR DESCRIPTION
…                                                                                                                                                                                                                                                                 RepositoryDiscovery now calls GitHubService.enrichJavaVersion() for                                                                                                any curated repo missing java_version, reading pom.xml / build.gradle                                                                                              via GitHub API and caching the result back into curated_repos.json.                                                                                                Subsequent runs use the cached value — no repeated API calls.