### PR TITLE
fix(#24): run Docker containers as host user to prevent root-owned files

### DIFF
--- a/src/main/java/com/swebench/pipeline/TestingSetup.java
+++ b/src/main/java/com/swebench/pipeline/TestingSetup.java
@@ -786,6 +786,7 @@ public class TestingSetup {
             w.println("    image=$(get_image \"$repo_name\")");
             w.println("    echo \"[$(date '+%H:%M:%S')] Starting: $repo_name ($image)\"");
             w.println("    docker run --rm \\");
+            w.println("        --user $(id -u):$(id -g) \\");
             w.println("        -v \"${repo_dir}\":/workspace \\");
             w.println("        -v \"$HOME/.m2\":/root/.m2 \\");
             w.println("        \"$image\" \\");


### PR DESCRIPTION
  Added --user \:\ to docker run so files written by git                                                                                                                                                           checkout/apply inside the container are owned by the host user. Without                                                                                                                                                          this, a Docker run leaves repo files owned by root, causing Permission                                                                                                                                                           Denied errors when the same repo is later validated natively.